### PR TITLE
Fix ImageDialog not being recognizable

### DIFF
--- a/electron/src/app/note/note.component.ts
+++ b/electron/src/app/note/note.component.ts
@@ -602,6 +602,7 @@ export class NoteComponent implements OnInit, OnDestroy {
     dialogRef.afterClosed().subscribe(result => {
       this.viewingImage = false;
     });
+  }
 
   imageHandler() {
     const input = document.createElement('input');


### PR DESCRIPTION
FIXED: ERROR in ImageDialog cannot be used as an entry component.